### PR TITLE
2 add 320h240v 4bitcolor support

### DIFF
--- a/BarnsleyFern.txt
+++ b/BarnsleyFern.txt
@@ -6,9 +6,9 @@
  
  50 REM Addresses for our four new functions from mapfile:
  55 LET      HGR = $E8B2  : REM F_HGR->init_bitmap_graphics()
- 60 LET    HPLOT = $E8B6  : REM F_HPLOT->draw_pixel()
- 65 LET TEXTMODE = $E8F2  : REM F_TEXT->init_console_text()
- 70 LET     HOME = $E8F6  : REM F_CLS->cls()
+ 60 LET    HPLOT = $E8BA  : REM F_HPLOT->draw_pixel()
+ 65 LET TEXTMODE = $E8F6  : REM F_TEXT->init_console_text()
+ 70 LET     HOME = $E8FA  : REM F_CLS->cls()
  75 LET      CLS = HOME   : REM cls()
  82 LET    GREEN = 10     : REM Green ON EHBASIC HPLOT 
 
@@ -23,7 +23,7 @@
 180  YX(4) =   0.26 : YY(4) = 0.24
 190  LET Y(4) = 0.44
 200  REM HGR :I =  PEEK (49234) : REM Applesoft HI-RES GRAPHICS NO TEXT
-202  CALL HGR : REM EhBASIC 
+202  CALL HGR,$FF : REM EhBASIC $FF means 320H x 240V x 4bpp
 210  REM HCOLOR= 1 : REM GREEN ON APPLE-II 
 220  LET X = 0    : Y = 0
 225  LET Xint = 0 : Yint = 0 : REM Applesoft has integer vars X% and Y% 
@@ -44,7 +44,8 @@
 
 320 REM  Y%   = 192 - Y * 19.1           : REM Original Applesoft
 322 REM  Yint = INT( 192 - (Y * 19.1) )
-324      Yint = INT( 180 - (Y * 17.9) )
+324 REM  Yint = INT( 180 - (Y * 17.9) ) : REM use for EhBASIC 320Hx180V mode
+325      Yint = INT( 240 - (Y * 23.9) ) : REM use for EhBASIC 320Hx240V mode
 
 330      REM  HPLOT X% * 2 + 1,Y%          : REM Applesoft
 333      IF Xint > 127 THEN LET Xint = 127 : REM Ensure HPLOT's x var is < 255

--- a/Mandelbrot.txt
+++ b/Mandelbrot.txt
@@ -1,14 +1,15 @@
   1 REM Mandelbrot ported from Applesoft BASIC. Ref: Rosettacode.org
   2 REM Addresses for our four new functions from mapfile:
   3 LET      HGR = $E8B2  : REM F_HGR->init_bitmap_graphics()
-  4 LET    HPLOT = $E8B6  : REM F_HPLOT->draw_pixel()
-  5 LET TEXTMODE = $E8F2  : REM F_TEXT->init_console_text()
-  6 LET     HOME = $E8F6  : REM F_CLS->cls()
+  4 LET    HPLOT = $E8BA : REM F_HPLOT->draw_pixel()
+  5 LET TEXTMODE = $E8F6  : REM F_TEXT->init_console_text()
+  6 LET     HOME = $E8FA  : REM F_CLS->cls()
   7 LET      CLS = HOME   : REM cls()
   8 LET    WHITE = 15     : REM white ON EHBASIC HPLOT. 
   9 REM EhBasic Colorrange 8(grey) 9(red) - 14(cyan) 15(wht); A2 ran 0(blk) - 7(wht2)
 
-10  CALL HGR
+10  REM call HGR with $FF for 320x240x4bpp(4:3); $00 for 320x180x8bpp(16:9) 
+11  CALL HGR,$FF
 20  XC = -0.5           : REM CENTER COORD X
 30  YC = 0              : REM   "      "   Y
 40  S = 2               : REM SCALE
@@ -23,7 +24,8 @@
 120 YM = YR / 191       : REM    "      "     "  Y
 130 FOR YI = 0 TO 3     : REM INTERLEAVE
 140   REM FOR YS = 0+YI TO 188+YI STEP 4 : REM Y SCREEN COORDINATE
-141   FOR YS = 0+YI TO 176+YI STEP 4 : REM EhBASIC y-limit hack
+141   REM FOR YS = 0+YI TO 176+YI STEP 4 : REM EhBASIC y-limit hack $00
+142   FOR YS = 0+YI TO 236+YI STEP 4 : REM EhBASIC y-limit hack $FF
 
 143   REM HCOLOR=3 : REM HPLOT 0,YS TO 279,YS : REM On A2: Clear-to-white 1st
 144   REM On pico6502, unnecessary to 1st clear each line to white

--- a/src/basgraf.c
+++ b/src/basgraf.c
@@ -4,9 +4,10 @@
  *
  * Functions:
  * 
- *     init_bitmap_graphics() - Setup bitmap display for either: 
- *                              0x00: 320h x 180v x 8-bit-per-pixel graphing canvas
- *                              0xFF: 320h x 240v x 4-bit-per-pixel
+ *     init_bitmap_graphics() - Setup bitmap display; clear it. 
+ *                              for either:
+ *                                0x00: 320 x 180  8-bit-per-pixel
+ *                                0xFF: 320 x 240  4-bit-per-pixel
  *         erase_canvas(void) - Clears the bitmapped display.
  *    draw_pixel(x, y, color) - Draws a pixel at position x,y of color
  *        init_console_text() - Setup display for console/text; clear it.
@@ -32,25 +33,36 @@
 //   Consider if we may want any of these of global-scope.
 //   Note that draw_pixel() has use for the canvas size too.
 
-static uint16_t canvas_w = 320;     //we are enforcing 320 x 180
-static uint16_t canvas_h = 180;     //we are enforcing 320 x 180
+/* default screen is 320h x 180v x 8bpp unless overriden */
+/* 
+ * Don't use static here in the combined C + EhBASIC environment
+  * statics found to be problematic.  We want to ensure active 
+  * variable initialization at run-time, not only at compile time.
+  * 
+  */
+/*static*/ uint16_t canvas_w = 320;     //we are either 320 x 180 or 320 x 240
+/*static*/ uint16_t canvas_h = 180;     //we are either 320 x 180 or 320 x 240
+/*static*/  uint8_t bpp_mode = 3;       //bits_per_pixel is 8
+/*static*/  uint8_t kr_canvas = 2;      //key-register canvas; either 2 or 1 
+                                    // use-2: 320x180 (16:9) our-original that worked
+                                    // use-1: 320x240 (4:3)
+                                    //other options (don't use for our EhBASIC)
+                                    // use-0 - 80 column console. (4:3 or 5:4)
+                                    // use-3 - 640x480 (4:3)
+                                    // use-4 - 640x360 (16:9)
 
-//static  uint8_t bpp_mode = 3;         /* bits_per_pixel =  8 */
 //static uint16_t canvas_struct = 0xFF00;
 //static uint16_t canvas_data   = 0x0000;
 //static  uint8_t plane = 0;
-//static  uint8_t canvas_mode = 2;
+
 
 
 
 // ---------------------------------------------------------------------------
-// Switch into bitmap-graphics mode, 320x180, 8-bit 256-colors, clear the screen.
+// Switch into selected bitmap-graphics mode, then clear the screen.
 // Can hook this as a 'HGR' command in EhBASIC (reference Applsoft Basic)
-// ntz - in general the entire rp6502 pico-VGA is difficult to understand
-// ntz - hence the comments here.
-// ntz - made void of parameters to ease the c / assembly parameter-calling linkage
 // ---------------------------------------------------------------------------
-void init_bitmap_graphics( void /*uint16_t canvas_struct_address,
+void init_bitmap_graphics( uint8_t dimension /*uint16_t canvas_struct_address,
                           uint16_t canvas_data_address,
                           uint8_t  canvas_plane,
                           uint8_t  canvas_type,
@@ -60,11 +72,13 @@ void init_bitmap_graphics( void /*uint16_t canvas_struct_address,
 {
 
     // initializers for the pico-VGA-HW
+
     uint16_t canvas_struct = 0xFF00;
     uint16_t canvas_data   = 0x0000;
     uint8_t  plane = 0;             //from RP6502-VGA docs: we have 3-planes; plane may be: 0, 1 or 2
-    uint8_t  bpp_mode = 3;          /* bits_per_pixel =  8 */
-    uint8_t  canvas_mode = 2;       /* 
+
+ // uint8_t  canvas_mode = 2;       
+                                    /* 
                                      *
                                      * ntz - to-do: I am confused by the 2 vs. 3 here from vruumllc's bitmap library code
                                      *       I believe this should be a 3, not a 2; but is hard-coded 
@@ -78,21 +92,38 @@ void init_bitmap_graphics( void /*uint16_t canvas_struct_address,
                                      *      4 - Sprite-mode
                                      *                              
                                      */ 
-                              
-         canvas_w = 320;     //we are enforcing 320 x 180
-         canvas_h = 180;     //we are enforcing 320 x 180
+
 
     /* bits_per_pixel = bpp = (2 ^ bpp_mode), for bpp_modes 0,1,2,3,4 */
     /* pico-VGA-HW needs bpp_mode, not bpp */
     /* we are only coding for our limited BASIC use case: bpp_mode-3, 8-bpp, 256-colors */
 //  bpp_mode = 0; /* bits_per_pixel =  1 */
 //  bpp_mode = 1; /* bits_per_pixel =  2 */
-//  bpp_mode = 2; /* bits_per_pixel =  4 */
-//  bpp_mode = 3; /* bits_per_pixel =  8 */  /* our case */
+//  bpp_mode = 2; /* bits_per_pixel =  4 */  /* our case when 320h x 240v */
+//  bpp_mode = 3; /* bits_per_pixel =  8 */  /* our case when 320h x 180v */
 //  bpp_mode = 4; /* bits_per_pixel = 16 */
 
+/* Don't rely on static compile-time initializations; ensure runtime initializers */
+    canvas_w  = 320;  //we are enforcing 320 width in both screen-size choices
 
-// Other good info to retain for possible code modifications:    
+    canvas_h  = 180;  //default canvas to 180 vertical high
+    bpp_mode  = 3;    //bits_per_pixel is 8; to ensure canvas memory < 64k-bytes
+    kr_canvas = 2;    //use-1: 320x180 (16:9)   
+
+    /* switch screen to 320h x 240v x 4bpp */
+    if (dimension == V240_H320_4BPP ) 
+    {
+         canvas_h  = 240;  //switch canvas to 240 vertical high
+         bpp_mode  = 2;    //bits_per_pixel is 4; to ensure canvas memory < 64k-bytes
+         kr_canvas = 1;    //use-1: 320x240 (4:3)
+//    } else {
+//       canvas_h  = 180;  //switch canvas to 180 vertical high
+//       bpp_mode  = 3;    //bits_per_pixel is 8; to ensure canvas memory < 64k-bytes
+//       kr_canvas = 2;    //use-1: 320x180 (16:9)       
+    } // end if(dimension)
+
+
+// Other good info from Vruumllc's efforts to retain for possible code modifications:    
 //  uint8_t x_offset = 0; //only needed for a bpp_mode=4, when initializing x_pos_px
 //  uint8_t y_offset = 0; //only needed for a bpp_mode=4, when initializing y_pos_px
 //  when bpp_mode==4 set x_offset = 30; /* (360 - 240)/4 */
@@ -121,23 +152,41 @@ void init_bitmap_graphics( void /*uint16_t canvas_struct_address,
     }
 #endif /*0*/
 
+#if 0
+    printf("dimension = %x\n", dimension);
+    printf("canvas_w  = %d\n", canvas_w );
+    printf("canvas_h  = %d\n", canvas_h );
+    printf("bpp_mode  = %d\n", bpp_mode);
+    printf("kr_canvas = %d\n", kr_canvas);
+#endif /*0*/
+
+
 
     // initialize the graphics canvas
     //
     //  note: xreg_vga_canvas( /*vargs*/ canvas_mode) is a macro that expands to:
-    //        xreg(1, 0, 0,              canvas_mode)
+    //        xreg(1, 0, 0,              kr_canvas was:canvas_mode)
     //
  // xreg_vga_canvas(canvas_mode);  //nzh: xreg_vga_canvas( /*canvas_mode=*/ 2 );
  // xreg_vga_canvas( /*canvas_mode=*/ 2);
-    xreg(1, 0, 0, 2);
+ // xreg(1, 0, 0, 2); // use-2: 320x180 (16:9) our-original that worked
+                      // use-1: 320x240 (4:3)
+
+                      // other options (don't use for our EhBASIC)
+                      // use-0 - 80 column console. (4:3 or 5:4)
+                      // use-3 - 640x480 (4:3)
+                      // use-4 - 640x360 (16:9)
+
+    xreg(1, 0, 0, kr_canvas);
+
 
     xram0_struct_set(canvas_struct, vga_mode3_config_t, x_wrap, false);
     xram0_struct_set(canvas_struct, vga_mode3_config_t, y_wrap, false);
     xram0_struct_set(canvas_struct, vga_mode3_config_t, x_pos_px,    0 /*x_offset*/);
     xram0_struct_set(canvas_struct, vga_mode3_config_t, y_pos_px,    0 /*y_offset*/);
-    xram0_struct_set(canvas_struct, vga_mode3_config_t, width_px,  320 /*canvas_w*/);
-    xram0_struct_set(canvas_struct, vga_mode3_config_t, height_px, 180 /*canvas_h*/);
-    xram0_struct_set(canvas_struct, vga_mode3_config_t, xram_data_ptr,  canvas_data);
+    xram0_struct_set(canvas_struct, vga_mode3_config_t,  width_px, HSIZE /*canvas_w*/);
+    xram0_struct_set(canvas_struct, vga_mode3_config_t, height_px, canvas_h); 
+    xram0_struct_set(canvas_struct, vga_mode3_config_t, xram_data_ptr,    canvas_data);
     xram0_struct_set(canvas_struct, vga_mode3_config_t, xram_palette_ptr, 0xFFFF);
 
     // initialize the bitmap video modes
@@ -150,7 +199,8 @@ void init_bitmap_graphics( void /*uint16_t canvas_struct_address,
 //  xreg_vga_mode(3,   bpp_mode,      canvas_struct, plane); // bitmap mode
 //  xreg_vga_mode(3, /*bpp_mode=*/ 3, canvas_struct, plane); // bitmap mode
     /*ntz - note the two '3's here; the 1st 3 was hard-coded in vruumllc's code */
-    xreg(1, 0, 1, 3, 3, canvas_struct, plane);
+//  xreg(1, 0, 1, 3, 3,        canvas_struct, plane);
+    xreg(1, 0, 1, 3, bpp_mode, canvas_struct, plane);
 
 
     erase_canvas(); 
@@ -160,29 +210,36 @@ void init_bitmap_graphics( void /*uint16_t canvas_struct_address,
 
 
 // ---------------------------------------------------------------------------
-// Clear the 320 x 180 8-bit-color screen.
-// ntz - in general the entire rp6502 pico-VGA is difficult to understand
-// ntz - hence the comments here.
+// Clear the screen.
+//
+// Screen memory cannot exceed 64kbytes.
+// For 320 x 180 8-bit-color = 320x180   bytes = 57,600 bytes < 64kbytes (good)
+// For 320 x 240 4-bit-color = 320x240/2 bytes = 38,400 bytes < 64kbytes (good) 
+//
 // ---------------------------------------------------------------------------
 void erase_canvas(void)
 {
     uint16_t i;
 //  uint16_t num_bytes;
-    uint16_t loops = 3600; 
+    uint16_t loops = 3600; //        loops       screen       bytes   inline-writes
+                           //default: 3600 for 320x180x8bpp = 57600 / 16-inline-writes-below
+                           //else is: 2400 for 320x240x4bpp = 38400 / 16-inline-writes-below
 
-//Note: for our BASIC special-case: canvas_w = 320 and canvas_h = 180 - always.
-// pre-multiplying: num_bytes = 57600 
+// Note: for our BASIC special-cases: canvas_w = 320 and canvas_h = 180-or-240.
+// pre-multiply the number of screen-bytes.
 
 //    num_bytes = canvas_w * canvas_h;  //note: we may NOT want to optimize this; 
                                         //      easier to support other canvas sizes.
-//    num_bytes = 57600; 
+//    num_bytes = 57600; //for 320x180x8bpp
 
-//  unrolled loop with 16 assignments needed to run num_bytes/16 = 3600 times. 
+//  determine #loops with 16 assignments needed to run num_bytes/16. 
+    if (canvas_h == 240 ) loops = 2400;  
+    
 
 //  RIA.addr0 = canvas_data;  /*canvas_data == 0x0000 for this erase loop*/
     RIA.addr0 = 0x0000;
     RIA.step0 = 1;
-//  for (i = 0; i < (num_bytes/16); i++) { /*num_bytes/16 = 3600 for our special-case*/
+//  for (i = 0; i < (num_bytes/16); i++) {  
     for (i = 0; i < loops; i++) {
         // unrolled for speed
         RIA.rw0 = 0; /* 1*/
@@ -209,7 +266,7 @@ void erase_canvas(void)
 
 // ---------------------------------------------------------------------------
 // Draw a pixel on the RP6502 screen, specifically for 320 x 180 x 8bpp mode.
-// Can hook this as a 'HPLOT' command in EhBASIC using existing 'CALL' keyword.
+// Can hook this as a 'HPLOT' command in EhBASIC
 //
 // ntz - This was challenging: linking the assembly-to-C parameter calling, 
 // ntz -  along with deciphering EhBASIC's parameters following its 'CALL' command.
@@ -222,16 +279,33 @@ void draw_pixel(uint16_t x, uint16_t y, uint16_t color)
 
         /* Ensure unsigned x limited to canvas_w and unsigned y limited to canvas_h */
 
-        x = ((x>319) ? 319 : x);
-        y = ((y>179) ? 179 : y);
+        x = ((x>319) ? 319 : x);  // could use HMAX define here
+        y = ((y>239) ? 239 : y);
+//      y = ((y>179) ? 179 : y);
+        if (canvas_h == 180 ) 
+            y = ((y>179) ? 179 : y);
 
-        //color = GREEN; //test: force green
+/***Begin: our previously demonstrated working case for 320x180x8bpp *****/
+////    RIA.addr0 = canvas_w * y + x;  /* canvas_w always 320 for our EhBASIC canvas */
+////    RIA.addr0 =      320 * y + x; 
+//      RIA.addr0 =    HSIZE * y + x; 
+//      RIA.step0 = 1;
+//      RIA.rw0 = color;  //ntz - note: color is 8-bits for our limited-case; yet is a uint16_t.
+/*****End: our previously demonstrated working case for 320x180x8bpp *****/
 
 
-        RIA.addr0 = canvas_w * y + x;  /* to-do: canvas_w always 320 for our special-case */
-//      RIA.addr0 =      320 * y + x; 
+/* begin: code fragment from Vruumllc with the 'magic' computation for 4bpp */
+    if (bpp_mode == 3) { // 8bpp
+        RIA.addr0 = canvas_w * y + x;  //easy to understand for 8bpp
         RIA.step0 = 1;
-        RIA.rw0 = color;  //ntz - note: color is 8-bits for our limited-case; yet is a uint16_t.
+        RIA.rw0 = color;
+    } else if (bpp_mode == 2) { // 4bpp - requires 'magic' :)
+        uint8_t shift = 4 * (1 - (x & 1));
+        RIA.addr0 = canvas_w/2 * y + x/2;
+        RIA.step0 = 0;
+        RIA.rw0 = (RIA.rw0 & ~(15 << shift)) | ((color & 15) << shift);
+    }
+/* end: Vruumllc 'magic' code-fragment */
 
 } //end draw_pixel()
 
@@ -244,9 +318,11 @@ void draw_pixel(uint16_t x, uint16_t y, uint16_t color)
 void init_console_text(void)
 {
 
-//  xreg_vga_mode(0); // console mode.  Macro expands to: xreg(1, 0, 1, 0);
-    xreg(1, 0, 1, 0); //ntz - difficult to understand 3rd param
-    xreg(1, 0, 0, 0); //ntz - diffucult to understand 4th param
+ // xreg_vga_canvas(0); // or
+    xreg(1, 0, 0, 0);   //kr_canvas = 0 means 80-column console
+
+ // xreg_vga_mode(0); // console mode.  Macro expands to: xreg(1, 0, 1, 0);
+    xreg(1, 0, 1, 0); // kr_mode = 0 means console
 
     // Erase console
 //  printf("\f");

--- a/src/basgraf.c
+++ b/src/basgraf.c
@@ -4,7 +4,9 @@
  *
  * Functions:
  * 
- *     init_bitmap_graphics() - Setup bitmap display for 320 x 180 8-bit-per-pixel. 
+ *     init_bitmap_graphics() - Setup bitmap display for either: 
+ *                              0x00: 320h x 180v x 8-bit-per-pixel graphing canvas
+ *                              0xFF: 320h x 240v x 4-bit-per-pixel
  *         erase_canvas(void) - Clears the bitmapped display.
  *    draw_pixel(x, y, color) - Draws a pixel at position x,y of color
  *        init_console_text() - Setup display for console/text; clear it.

--- a/src/basgraf.h
+++ b/src/basgraf.h
@@ -4,7 +4,10 @@
  *
  * Function headers for:
  * 
- *     init_bitmap_graphics() - Setup bitmap display for 1-of-2-modes: 320 x 180||240 x 8|4-bpp; clear it. 
+ *     init_bitmap_graphics(dimension) - Setup bitmap display; clear it. 
+ *                              for either:
+ *                                0x00: 320 x 180  8-bit-per-pixel
+ *                                0xFF: 320 x 240  4-bit-per-pixel
  *         erase_canvas(void) - Clears the bitmapped display.
  *    draw_pixel(x, y, color) - Draws a pixel at position x,y of color
  *        init_console_text() - Setup display for console/text; clear it.
@@ -76,10 +79,14 @@ void init_bitmap_graphics(uint16_t canvas_struct_address,
                           uint8_t  bits_per_pixel);
 #endif /*0*/
 
-#define V180_H320_8BPP 0x00 //320h x 180v x 8-bpp-color 
-#define V240_H320_4BPP 0XFF //320H X 240V X 4-bpp-color
+/* #defines for desired screen dimension */
+#define V180_H320_8BPP 0x00
+#define V240_H320_4BPP 0xFF
 
-void init_bitmap_graphics(void);
+#define HSIZE 320 /* always 320 for our use-case */
+#define HMAX  ( HSIZE - 1 ) /* max x-pixel */
+
+void init_bitmap_graphics(uint8_t dimension);
 void erase_canvas(void);
 void draw_pixel(uint16_t x, uint16_t y, uint16_t color);
 

--- a/src/basgraf.h
+++ b/src/basgraf.h
@@ -4,7 +4,7 @@
  *
  * Function headers for:
  * 
- *     init_bitmap_graphics() - Setup bitmap display for 320 x 180 8-bit-per-pixel; clear it. 
+ *     init_bitmap_graphics() - Setup bitmap display for 1-of-2-modes: 320 x 180||240 x 8|4-bpp; clear it. 
  *         erase_canvas(void) - Clears the bitmapped display.
  *    draw_pixel(x, y, color) - Draws a pixel at position x,y of color
  *        init_console_text() - Setup display for console/text; clear it.
@@ -75,6 +75,9 @@ void init_bitmap_graphics(uint16_t canvas_struct_address,
                           uint16_t canvas_height,
                           uint8_t  bits_per_pixel);
 #endif /*0*/
+
+#define V180_H320_8BPP 0x00 //320h x 180v x 8-bpp-color 
+#define V240_H320_4BPP 0XFF //320H X 240V X 4-bpp-color
 
 void init_bitmap_graphics(void);
 void erase_canvas(void);

--- a/src/rp6502enhance.s
+++ b/src/rp6502enhance.s
@@ -14,7 +14,7 @@
 
 ;
 ; The following imports from ca65 libraries were difficult to find 
-; but proofed to be key in integrating EnBasci-assembly -> C calling parameters.  
+; but proved to be key in integrating EnBasci-assembly -> C calling parameters.  
 ; This greatly aided parameter/stack prep in using the added EhBasic 'CALL' command 
 ; parameters 'HPLOT,x,y,color' prior to call the c-function _plot_pixel().
 ; 
@@ -31,11 +31,15 @@ AA_begin_enhancements:
 ;       the EhBASIC-interpreter executable code.
 ;       For now, they will be CALL'ed via BASIC's 'CALL' command.
 ; 
-F_HGR:
+F_HGR:      ; HGR now has 1-parameter: dimension-flag 0x00=320x180x8bpp 0xFF=320x240x4bpp
+      JSR   LAB_SCGB        ; scan for "," then get dimension byte in x-reg. 
+                            ; Else syntax-error, warm start.
+      txa                   ; Transfer x-reg to a-reg, our screen-dimension-flag byte
+                            ; before doing our c-call to:
       jmp _init_bitmap_graphics
       rts ; for safety
 
-F_HPLOT:
+F_HPLOT:                    ; HPLOT has 3-parameters: x, y, color 
       JSR   LAB_SCGB        ; scan for "," and get byte. Else syntax-error, warm start.
       STX   PLOT_XBYT       ; save plot x
       JSR   LAB_SCGB        ; scan for "," and get byte


### PR DESCRIPTION
Adding 320h240v 4bitcolor support to the existing 320h180v 8bit color mode.  Tested both the new and old screen-dimension-modes successfully on the HW with both the two EhBASIC programs : BarnsleyFern.txt and Mandelbrot.txt.